### PR TITLE
Fix calculate price deadline

### DIFF
--- a/lib/auxiliars/helper.rb
+++ b/lib/auxiliars/helper.rb
@@ -74,6 +74,8 @@ class Helper < CorreiosException
   # Converters
 
   def string_to_bool(string)
+    return false if string.nil?
+
     string.strip == 'S'
   end
 

--- a/lib/auxiliars/helper.rb
+++ b/lib/auxiliars/helper.rb
@@ -65,7 +65,7 @@ class Helper < CorreiosException
     else
       days.to_i.times do
         date += 1.days
-        date += 1.days if deadline.sunday? || deadline.saturday?
+        date += 1.days if date.on_weekend?
       end
     end
     date


### PR DESCRIPTION
Fixes 2 bugs found in `Correios::Pricefier.calculate_price_deadline`:
- There was a call to a non-existing variable called "deadline" - seems to be a confusion where it should be calling "date"
- There are cases where the API responds with a null `entrega_sabado`, instead of S or N - that case wasn't being handled.